### PR TITLE
chore: remove unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,8 @@ serde_yaml = "0.9"
 serde_json = "1.0"
 anyhow = "1.0"
 colored = "2.1"
-dirs = "5.0"
-which = "6.0"
 chrono = { version = "0.4", features = ["serde"] }
 tabled = "0.16"
-reqwest = { version = "0.12", features = ["json", "blocking"] }
-open = "5.0"
 
 [build-dependencies]
 clap = { version = "4.5", features = ["derive", "cargo", "env"] }


### PR DESCRIPTION
## Summary
- Removes 4 unused runtime dependencies: `dirs`, `which`, `reqwest`, `open`
- Identified using `cargo-machete` static analysis tool
- Reduces binary size and compilation time
- No functional changes - all existing features work the same

## Dependencies Removed
- **dirs**: Not used for directory operations
- **which**: Not used for executable discovery  
- **reqwest**: GitHub integration uses `gh` CLI instead of HTTP API
- **open**: Not used for opening URLs/files

## Test plan
- [x] Project builds successfully with `cargo build --release`
- [x] All core functionality verified working
- [x] Dependencies confirmed unused via code analysis

🤖 Generated with [Claude Code](https://claude.ai/code)